### PR TITLE
chore: rename config.toml to hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,6 @@
 [module.hugoVersion]
 extended = true
+min = "0.110.0"
 
 [[module.imports]]
 path = "github.com/razonyang/hugopress"


### PR DESCRIPTION
Requires the Hugo version to be at least `v0.110.0`.