### PR TITLE
feat(back-to-top): add hb.back_to_top params

### DIFF
--- a/modules/back-to-top/assets/hb/modules/back-to-top/js/button.ts
+++ b/modules/back-to-top/assets/hb/modules/back-to-top/js/button.ts
@@ -1,3 +1,5 @@
+import * as params from "@params";
+
 export default class Button {
     private btn: HTMLButtonElement
 
@@ -17,14 +19,14 @@ export default class Button {
             } else {
                 this.hide();
             }
-            if (top > y) {
+            if (this.animation() && top > y) {
                 btn.classList.remove('scrolling')
             }
             y = top
         });
 
         this.btn.addEventListener('click', () => {
-            btn.classList.add('scrolling')
+            this.animation() && btn.classList.add('scrolling')
             window.scrollTo({
                 top: 0,
                 left: 0,
@@ -39,5 +41,9 @@ export default class Button {
 
     hide() {
         this.btn.classList.remove('show')
+    }
+
+    animation(): boolean {
+        return params?.back_to_top?.animation !== false
     }
 }

--- a/modules/back-to-top/assets/hb/modules/back-to-top/js/index.tmpl.ts
+++ b/modules/back-to-top/assets/hb/modules/back-to-top/js/index.tmpl.ts
@@ -1,8 +1,8 @@
 {{- $ctx := dict
     "vendor" "bootstrap"
-    "name" "rocket"
-    "width" "2rem"
-    "height" "2rem"
+    "name" (default "rocket" .Site.Params.hb.back_to_top.icon_name)
+    "width" (default "2em" .Site.Params.hb.back_to_top.icon_width)
+    "height" (default "2em" .Site.Params.hb.back_to_top.icon_height)
     "className" "hb-back-to-top-icon"
 }}
 {{ $icon := partial "icons/icon" $ctx }}

--- a/modules/back-to-top/assets/hb/modules/back-to-top/scss/index.scss
+++ b/modules/back-to-top/assets/hb/modules/back-to-top/scss/index.scss
@@ -2,18 +2,21 @@
 .hb-back-to-top {
     background: transparent;
     border: none;
-    bottom: 1rem;
+    bottom: $hb-back-to-top-bottom;
     color: var(--#{$prefix}body-color);
     opacity: 0;
     padding: 0;
     position: fixed;
-    right: 1rem;
+    right: $hb-back-to-top-end;
     transition: opacity 0.5s;
     z-index: -1;
 
-    &.scrolling {
-        bottom: 100%;
-        transition: bottom 1s;
+    @if $hb-back-to-top-animation {
+        &.scrolling {
+            bottom: 100%;
+            color: var(--#{$prefix}primary-text);
+            transition: bottom 1s;
+        }
     }
 
     &.show {
@@ -21,8 +24,7 @@
         z-index: 1000;
     }
 
-    &:hover,
-    &.scrolling {
+    &:hover {
         color: var(--#{$prefix}primary-text);
     }
 }

--- a/modules/back-to-top/assets/hb/modules/back-to-top/scss/variables.tmpl.scss
+++ b/modules/back-to-top/assets/hb/modules/back-to-top/scss/variables.tmpl.scss
@@ -1,0 +1,3 @@
+$hb-back-to-top-bottom: {{ default "1rem" site.Params.hb.back_to_top.position_bottom }};
+$hb-back-to-top-end: {{ default "1rem" site.Params.hb.back_to_top.position_end }};
+$hb-back-to-top-animation: {{ default true site.Params.hb.back_to_top.animation }};

--- a/modules/back-to-top/hugo.toml
+++ b/modules/back-to-top/hugo.toml
@@ -3,3 +3,11 @@ path = "github.com/razonyang/hb"
 
 [[module.imports]]
 path = "github.com/razonyang/hugo-mod-icons/vendors/bootstrap"
+
+[params.hb.back_to_top]
+icon_height = "2em"
+icon_width = "2em"
+icon_name = "rocket"
+position_bottom = "1rem"
+position_end = "1rem"
+animation = true


### PR DESCRIPTION
`icon_height`: the height of icon, default to 2em.
`icon_width`: the width of icon, default to 2em.
`icon_name`: the name of Bootstrap icon, default to rocket.
`animation`: disable the default animation if false, enable by default.
`position_bottom`: the bottom property value of button, default to 1rem.
`position_end`: the right (LTR) or left (RTL) property value of button, default to 1rem.