### PR TITLE
feat(base): add the full_width parameters

### DIFF
--- a/modules/base/hugo.toml
+++ b/modules/base/hugo.toml
@@ -16,5 +16,10 @@ path = "github.com/razonyang/hugo-mod-icons"
 [[module.imports]]
 path = "github.com/razonyang/hugo-mod-icons/vendors/bootstrap"
 
+[params.hb.base.full_width]
+types = ["docs"]
+# kinds = ["home"]
+# sections = ["docs", "notes"]
+
 [params.hb.terms]
 paginate = 9

--- a/modules/base/layouts/_default/baseof.html
+++ b/modules/base/layouts/_default/baseof.html
@@ -11,7 +11,9 @@
     {{- partial "hugopress/body-begin.html" . }}
     {{ partial "hb/modules/header/index" . }}
     {{ partial "hugopress/functions/render-hooks" (dict "Name" "hb-main-begin" "Page" .) }}
-    <div class="hb-main container-xxl">
+    {{- $fullWidthKey := dict "type" .Type "section" .Section "kind" .Kind }}
+    {{- $fullWidth := partialCached "hb/modules/base/functions/full-width" . $fullWidthKey }}
+    <div class="hb-main {{ cond $fullWidth `container-fluid` `container-xxl` }}">
       {{- block "main" . }}{{- end }}
     </div>
     {{ partial "hugopress/functions/render-hooks" (dict "Name" "hb-main-end" "Page" .) }}

--- a/modules/base/layouts/partials/hb/modules/base/functions/full-width.html
+++ b/modules/base/layouts/partials/hb/modules/base/functions/full-width.html
@@ -1,0 +1,14 @@
+{{- $full := false }}
+{{- $page := . }}
+{{- with .Site.Params.hb.base.full_width }}
+  {{- with .kinds }}
+    {{- $full = in . $page.Kind }}
+  {{- end }}
+  {{- with .sections }}
+    {{- $full = in . $page.Section }}
+  {{- end }}
+  {{- with .types }}
+    {{- $full = in . $page.Type }}
+  {{- end }}
+{{- end }}
+{{- return $full -}}


### PR DESCRIPTION
Parameters:
`kinds`: array of page's kinds.
`sections`: array of page's sections.
`types`: array of page's types.

For example:
```toml
[params.hb.base.full_width]
types = ["docs"]
kinds = ["home"]
sections = ["docs", "notes"]
```